### PR TITLE
Initial Flutter scaffold with navigation and Hive persistence

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.budget_balanced">
+    <uses-permission android:name="android.permission.CAMERA" />
+    <application android:label="Budget Balanced" android:icon="@mipmap/ic_launcher">
+        <activity android:name=".MainActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSCameraUsageDescription</key>
+  <string>Need camera for receipt scanning</string>
+</dict>
+</plist>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'router.dart';
+import 'theme.dart';
+
+class App extends ConsumerWidget {
+  const App({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+    return MaterialApp.router(
+      title: 'Budget Balanced',
+      theme: lightTheme,
+      darkTheme: darkTheme,
+      routerConfig: router,
+    );
+  }
+}

--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/transaction.dart';
+import '../../data/repos/transaction_repo.dart';
+import '../../data/repos/budget_repo.dart';
+import '../../data/repos/goal_repo.dart';
+
+final transactionsProvider = StreamProvider<List<Transaction>>((ref) {
+  final repo = ref.watch(transactionRepoProvider);
+  return repo.watchAll();
+});
+
+final budgetsRepoProvider = budgetRepoProvider;
+final goalsRepoProvider = goalRepoProvider;

--- a/lib/core/utils/currency.dart
+++ b/lib/core/utils/currency.dart
@@ -1,0 +1,12 @@
+import 'package:intl/intl.dart';
+
+final _currencyFormat = NumberFormat.simpleCurrency();
+
+String formatCents(int amount) {
+  return _currencyFormat.format(amount / 100);
+}
+
+int parseCurrency(String input) {
+  final value = _currencyFormat.parse(input).toDouble();
+  return (value * 100).round();
+}

--- a/lib/data/models/attachment.dart
+++ b/lib/data/models/attachment.dart
@@ -1,0 +1,17 @@
+import 'package:hive/hive.dart';
+
+@HiveType(typeId: 3)
+class Attachment extends HiveObject {
+  Attachment({
+    required this.id,
+    required this.imagePath,
+    this.ocrJson,
+  });
+
+  @HiveField(0)
+  String id;
+  @HiveField(1)
+  String imagePath;
+  @HiveField(2)
+  String? ocrJson;
+}

--- a/lib/data/models/budget.dart
+++ b/lib/data/models/budget.dart
@@ -1,0 +1,23 @@
+import 'package:hive/hive.dart';
+
+@HiveType(typeId: 1)
+class Budget extends HiveObject {
+  Budget({
+    required this.id,
+    required this.periodMonth,
+    required this.periodYear,
+    required this.categoryLimits,
+    this.rolloverEnabled = false,
+  });
+
+  @HiveField(0)
+  String id;
+  @HiveField(1)
+  int periodMonth;
+  @HiveField(2)
+  int periodYear;
+  @HiveField(3)
+  Map<String, int> categoryLimits;
+  @HiveField(4)
+  bool rolloverEnabled;
+}

--- a/lib/data/models/goal.dart
+++ b/lib/data/models/goal.dart
@@ -1,0 +1,23 @@
+import 'package:hive/hive.dart';
+
+@HiveType(typeId: 2)
+class Goal extends HiveObject {
+  Goal({
+    required this.id,
+    required this.name,
+    required this.targetCents,
+    this.targetDateUtc,
+    this.savedCents = 0,
+  });
+
+  @HiveField(0)
+  String id;
+  @HiveField(1)
+  String name;
+  @HiveField(2)
+  int targetCents;
+  @HiveField(3)
+  DateTime? targetDateUtc;
+  @HiveField(4)
+  int savedCents;
+}

--- a/lib/data/models/transaction.dart
+++ b/lib/data/models/transaction.dart
@@ -1,0 +1,36 @@
+import 'package:hive/hive.dart';
+
+
+@HiveType(typeId: 0)
+class Transaction extends HiveObject {
+  Transaction({
+    required this.id,
+    required this.amountCents,
+    required this.dateUtc,
+    this.merchant,
+    this.category,
+    this.paymentType,
+    this.note,
+    this.source,
+    this.attachmentId,
+  });
+
+  @HiveField(0)
+  String id;
+  @HiveField(1)
+  int amountCents;
+  @HiveField(2)
+  DateTime dateUtc;
+  @HiveField(3)
+  String? merchant;
+  @HiveField(4)
+  String? category;
+  @HiveField(5)
+  String? paymentType;
+  @HiveField(6)
+  String? note;
+  @HiveField(7)
+  String? source;
+  @HiveField(8)
+  String? attachmentId;
+}

--- a/lib/data/repos/budget_repo.dart
+++ b/lib/data/repos/budget_repo.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../models/budget.dart';
+import '../storage/hive_boxes.dart';
+
+final budgetRepoProvider = Provider((ref) => BudgetRepo());
+
+class BudgetRepo {
+  Box<Budget> get _box => Hive.box<Budget>(budgetsBox);
+
+  Stream<List<Budget>> watchAll() {
+    return _box.watch().map((_) => _box.values.toList());
+  }
+
+  Future<void> save(Budget budget) async {
+    await _box.put(budget.id, budget);
+  }
+
+  Future<void> remove(String id) async {
+    await _box.delete(id);
+  }
+}

--- a/lib/data/repos/goal_repo.dart
+++ b/lib/data/repos/goal_repo.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../models/goal.dart';
+import '../storage/hive_boxes.dart';
+
+final goalRepoProvider = Provider((ref) => GoalRepo());
+
+class GoalRepo {
+  Box<Goal> get _box => Hive.box<Goal>(goalsBox);
+
+  Stream<List<Goal>> watchAll() {
+    return _box.watch().map((_) => _box.values.toList());
+  }
+
+  Future<void> save(Goal goal) async {
+    await _box.put(goal.id, goal);
+  }
+
+  Future<void> remove(String id) async {
+    await _box.delete(id);
+  }
+}

--- a/lib/data/repos/transaction_repo.dart
+++ b/lib/data/repos/transaction_repo.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../models/transaction.dart';
+import '../storage/hive_boxes.dart';
+
+final transactionRepoProvider = Provider((ref) => TransactionRepo());
+
+class TransactionRepo {
+  Box<Transaction> get _box => Hive.box<Transaction>(transactionsBox);
+
+  Stream<List<Transaction>> watchAll() {
+    return _box.watch().map((_) => _box.values.toList());
+  }
+
+  Future<void> add(Transaction tx) async {
+    await _box.put(tx.id, tx);
+  }
+
+  Future<void> update(Transaction tx) async {
+    await _box.put(tx.id, tx);
+  }
+
+  Future<void> remove(String id) async {
+    await _box.delete(id);
+  }
+}

--- a/lib/data/storage/hive_adapters.dart
+++ b/lib/data/storage/hive_adapters.dart
@@ -1,0 +1,128 @@
+import 'package:hive/hive.dart';
+
+import '../models/transaction.dart';
+import '../models/budget.dart';
+import '../models/goal.dart';
+import '../models/attachment.dart';
+
+void registerHiveAdapters() {
+  Hive.registerAdapter(TransactionAdapter());
+  Hive.registerAdapter(BudgetAdapter());
+  Hive.registerAdapter(GoalAdapter());
+  Hive.registerAdapter(AttachmentAdapter());
+}
+
+class TransactionAdapter extends TypeAdapter<Transaction> {
+  @override
+  final int typeId = 0;
+
+  @override
+  Transaction read(BinaryReader reader) {
+    String? _nullify(String value) => value.isEmpty ? null : value;
+    return Transaction(
+      id: reader.readString(),
+      amountCents: reader.readInt(),
+      dateUtc: DateTime.parse(reader.readString()),
+      merchant: _nullify(reader.readString()),
+      category: _nullify(reader.readString()),
+      paymentType: _nullify(reader.readString()),
+      note: _nullify(reader.readString()),
+      source: _nullify(reader.readString()),
+      attachmentId: _nullify(reader.readString()),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Transaction obj) {
+    writer
+      ..writeString(obj.id)
+      ..writeInt(obj.amountCents)
+      ..writeString(obj.dateUtc.toIso8601String())
+      ..writeString(obj.merchant ?? '')
+      ..writeString(obj.category ?? '')
+      ..writeString(obj.paymentType ?? '')
+      ..writeString(obj.note ?? '')
+      ..writeString(obj.source ?? '')
+      ..writeString(obj.attachmentId ?? '');
+  }
+}
+
+class BudgetAdapter extends TypeAdapter<Budget> {
+  @override
+  final int typeId = 1;
+
+  @override
+  Budget read(BinaryReader reader) {
+    final id = reader.readString();
+    final month = reader.readInt();
+    final year = reader.readInt();
+    final limits = Map<String, int>.from(reader.readMap());
+    final rollover = reader.readBool();
+    return Budget(
+      id: id,
+      periodMonth: month,
+      periodYear: year,
+      categoryLimits: limits,
+      rolloverEnabled: rollover,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Budget obj) {
+    writer
+      ..writeString(obj.id)
+      ..writeInt(obj.periodMonth)
+      ..writeInt(obj.periodYear)
+      ..writeMap(obj.categoryLimits)
+      ..writeBool(obj.rolloverEnabled);
+  }
+}
+
+class GoalAdapter extends TypeAdapter<Goal> {
+  @override
+  final int typeId = 2;
+
+  @override
+  Goal read(BinaryReader reader) {
+    return Goal(
+      id: reader.readString(),
+      name: reader.readString(),
+      targetCents: reader.readInt(),
+      targetDateUtc: reader.readBool() ? DateTime.parse(reader.readString()) : null,
+      savedCents: reader.readInt(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Goal obj) {
+    writer
+      ..writeString(obj.id)
+      ..writeString(obj.name)
+      ..writeInt(obj.targetCents)
+      ..writeBool(obj.targetDateUtc != null)
+      ..writeString(obj.targetDateUtc?.toIso8601String() ?? '')
+      ..writeInt(obj.savedCents);
+  }
+}
+
+class AttachmentAdapter extends TypeAdapter<Attachment> {
+  @override
+  final int typeId = 3;
+
+  @override
+  Attachment read(BinaryReader reader) {
+    return Attachment(
+      id: reader.readString(),
+      imagePath: reader.readString(),
+      ocrJson: reader.readString(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Attachment obj) {
+    writer
+      ..writeString(obj.id)
+      ..writeString(obj.imagePath)
+      ..writeString(obj.ocrJson ?? '');
+  }
+}

--- a/lib/data/storage/hive_boxes.dart
+++ b/lib/data/storage/hive_boxes.dart
@@ -1,0 +1,18 @@
+import 'package:hive/hive.dart';
+
+import '../models/transaction.dart';
+import '../models/budget.dart';
+import '../models/goal.dart';
+import '../models/attachment.dart';
+
+const transactionsBox = 'transactions';
+const budgetsBox = 'budgets';
+const goalsBox = 'goals';
+const attachmentsBox = 'attachments';
+
+Future<void> openHiveBoxes() async {
+  await Hive.openBox<Transaction>(transactionsBox);
+  await Hive.openBox<Budget>(budgetsBox);
+  await Hive.openBox<Goal>(goalsBox);
+  await Hive.openBox<Attachment>(attachmentsBox);
+}

--- a/lib/features/budgets/budgets_page.dart
+++ b/lib/features/budgets/budgets_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class BudgetsPage extends StatelessWidget {
+  const BudgetsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(title: Text('Budgets')),
+      body: Center(child: Text('No budgets yet')),
+    );
+  }
+}

--- a/lib/features/dashboard/dashboard_page.dart
+++ b/lib/features/dashboard/dashboard_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+import '../../widgets/chart_spend_vs_budget.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          Text('This Month Spend'),
+          SizedBox(height: 16),
+          ChartSpendVsBudget(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/goals/goals_page.dart
+++ b/lib/features/goals/goals_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class GoalsPage extends StatelessWidget {
+  const GoalsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(title: Text('Goals')),
+      body: Center(child: Text('No goals yet')),
+    );
+  }
+}

--- a/lib/features/receipt_scan/receipt_flow.dart
+++ b/lib/features/receipt_scan/receipt_flow.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class ReceiptFlow extends StatefulWidget {
+  const ReceiptFlow({super.key});
+
+  @override
+  State<ReceiptFlow> createState() => _ReceiptFlowState();
+}
+
+class _ReceiptFlowState extends State<ReceiptFlow> {
+  bool _captured = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Scan Receipt')),
+      body: Center(
+        child: _captured
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('Dummy receipt preview'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Attach to Transaction'),
+                  ),
+                ],
+              )
+            : ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    _captured = true;
+                  });
+                },
+                child: const Text('Simulate Capture'),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(title: Text('Settings')),
+      body: Center(child: Text('Settings go here')),
+    );
+  }
+}

--- a/lib/features/transactions/add_transaction_sheet.dart
+++ b/lib/features/transactions/add_transaction_sheet.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/di/providers.dart';
+import '../../core/utils/currency.dart';
+import '../../data/models/transaction.dart';
+
+class AddTransactionSheet extends ConsumerStatefulWidget {
+  const AddTransactionSheet({super.key});
+
+  @override
+  ConsumerState<AddTransactionSheet> createState() => _AddTransactionSheetState();
+}
+
+class _AddTransactionSheetState extends ConsumerState<AddTransactionSheet> {
+  final _amountController = TextEditingController();
+  final _merchantController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: MediaQuery.of(context).viewInsets.add(const EdgeInsets.all(16)),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _amountController,
+            decoration: const InputDecoration(labelText: 'Amount'),
+            keyboardType: TextInputType.number,
+          ),
+          TextField(
+            controller: _merchantController,
+            decoration: const InputDecoration(labelText: 'Merchant'),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              final amount = parseCurrency(_amountController.text);
+              final tx = Transaction(
+                id: DateTime.now().millisecondsSinceEpoch.toString(),
+                amountCents: amount,
+                dateUtc: DateTime.now().toUtc(),
+                merchant: _merchantController.text,
+              );
+              ref.read(transactionRepoProvider).add(tx);
+              Navigator.of(context).pop();
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/transactions/transactions_page.dart
+++ b/lib/features/transactions/transactions_page.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/di/providers.dart';
+import 'add_transaction_sheet.dart';
+import '../receipt_scan/receipt_flow.dart';
+import '../../core/utils/currency.dart';
+
+class TransactionsPage extends ConsumerWidget {
+  const TransactionsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final transactions = ref.watch(transactionsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Transactions'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.camera_alt),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const ReceiptFlow()),
+              );
+            },
+          ),
+        ],
+      ),
+      body: transactions.when(
+        data: (items) => ListView.builder(
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final tx = items[index];
+            return ListTile(
+              title: Text(tx.merchant ?? 'Unknown'),
+              subtitle: Text(tx.note ?? ''),
+              trailing: Text(formatCents(tx.amountCents)),
+            );
+          },
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => Center(child: Text('Error: $e')),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          showModalBottomSheet(
+            context: context,
+            isScrollControlled: true,
+            builder: (_) => const AddTransactionSheet(),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'app.dart';
+import 'data/storage/hive_adapters.dart';
+import 'data/storage/hive_boxes.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
+  registerHiveAdapters();
+  await openHiveBoxes();
+  runApp(const ProviderScope(child: App()));
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'features/dashboard/dashboard_page.dart';
+import 'features/transactions/transactions_page.dart';
+import 'features/budgets/budgets_page.dart';
+import 'features/goals/goals_page.dart';
+import 'features/settings/settings_page.dart';
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      ShellRoute(
+        builder: (context, state, child) => _ScaffoldWithNav(child: child),
+        routes: [
+          GoRoute(path: '/', builder: (context, state) => const DashboardPage()),
+          GoRoute(path: '/transactions', builder: (context, state) => const TransactionsPage()),
+          GoRoute(path: '/budgets', builder: (context, state) => const BudgetsPage()),
+          GoRoute(path: '/goals', builder: (context, state) => const GoalsPage()),
+          GoRoute(path: '/settings', builder: (context, state) => const SettingsPage()),
+        ],
+      ),
+    ],
+  );
+});
+
+class _ScaffoldWithNav extends StatelessWidget {
+  const _ScaffoldWithNav({required this.child});
+  final Widget child;
+
+  static int _locationToIndex(String location) {
+    switch (location) {
+      case '/':
+        return 0;
+      case '/transactions':
+        return 1;
+      case '/budgets':
+        return 2;
+      case '/goals':
+        return 3;
+      case '/settings':
+        return 4;
+      default:
+        return 0;
+    }
+  }
+
+  void _onItemTapped(BuildContext context, int index) {
+    switch (index) {
+      case 0:
+        context.go('/');
+        break;
+      case 1:
+        context.go('/transactions');
+        break;
+      case 2:
+        context.go('/budgets');
+        break;
+      case 3:
+        context.go('/goals');
+        break;
+      case 4:
+        context.go('/settings');
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final location = GoRouter.of(context).location;
+    final currentIndex = _locationToIndex(location);
+    return Scaffold(
+      body: child,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: currentIndex,
+        onTap: (index) => _onItemTapped(context, index),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Dashboard'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Transactions'),
+          BottomNavigationBarItem(icon: Icon(Icons.pie_chart), label: 'Budgets'),
+          BottomNavigationBarItem(icon: Icon(Icons.flag), label: 'Goals'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+final lightTheme = ThemeData(
+  colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+  useMaterial3: true,
+);
+
+final darkTheme = ThemeData(
+  colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal, brightness: Brightness.dark),
+  useMaterial3: true,
+);

--- a/lib/widgets/chart_spend_vs_budget.dart
+++ b/lib/widgets/chart_spend_vs_budget.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class ChartSpendVsBudget extends StatelessWidget {
+  const ChartSpendVsBudget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 200,
+      color: Colors.teal.shade100,
+      child: const Center(child: Text('Chart Placeholder')),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,22 @@
+name: budget_balanced
+description: A personal budgeting app
+publish_to: 'none'
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.4.0
+  go_router: ^13.0.0
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  intl: ^0.18.0
+  path_provider: ^2.0.14
+  collection: ^1.17.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.0

--- a/test/unit/transaction_repo_test.dart
+++ b/test/unit/transaction_repo_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:budget_balanced/data/models/transaction.dart';
+import 'package:budget_balanced/data/storage/hive_adapters.dart';
+import 'package:budget_balanced/data/storage/hive_boxes.dart';
+import 'package:budget_balanced/data/repos/transaction_repo.dart';
+
+void main() {
+  setUp(() async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    registerHiveAdapters();
+    await Hive.openBox<Transaction>(transactionsBox);
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk(transactionsBox);
+  });
+
+  test('CRUD operations', () async {
+    final repo = TransactionRepo();
+    final tx = Transaction(
+      id: '1',
+      amountCents: 100,
+      dateUtc: DateTime.utc(2023, 1, 1),
+      merchant: 'Test',
+    );
+    await repo.add(tx);
+    expect((await repo.watchAll().first).length, 1);
+    await repo.remove('1');
+    expect((await repo.watchAll().first).length, 0);
+  });
+}

--- a/test/widget/smoke_test.dart
+++ b/test/widget/smoke_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import 'package:budget_balanced/app.dart';
+import 'package:budget_balanced/data/models/transaction.dart';
+import 'package:budget_balanced/data/storage/hive_adapters.dart';
+import 'package:budget_balanced/data/storage/hive_boxes.dart';
+
+void main() {
+  setUp(() async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    registerHiveAdapters();
+    await openHiveBoxes();
+  });
+
+  testWidgets('add transaction flow', (tester) async {
+    await tester.pumpWidget(const ProviderScope(child: App()));
+    await tester.pumpAndSettle();
+
+    // Navigate to transactions tab
+    await tester.tap(find.text('Transactions'));
+    await tester.pumpAndSettle();
+
+    // Open add sheet
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, '1');
+    await tester.enterText(find.byType(TextField).last, 'Coffee');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Coffee'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold Flutter app with bottom navigation, Riverpod state, and GoRouter
- add Hive models and repositories for transactions, budgets, goals, and attachments
- implement transaction add flow, receipt scan stub, and placeholder chart
- include Android/iOS camera permissions and basic tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897e3c9b0308331936cfe74cd8ee583