### PR TITLE
Add current month budgeting with dashboard overview

### DIFF
--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -2,7 +2,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
 import '../../data/models/transaction.dart';
+import '../../data/models/budget.dart';
 import '../../data/repos/transaction_repo.dart';
+import '../../data/repos/budget_repo.dart';
 import '../../data/storage/hive_boxes.dart';
 
 final hiveReadyProvider = FutureProvider<void>((ref) async {
@@ -20,6 +22,90 @@ final transactionsProvider = StreamProvider<List<BBTransaction>>((ref) {
   return repo.watchAll();
 });
 
+final budgetRepoProvider = Provider<BudgetRepo>((ref) {
+  ref.watch(hiveReadyProvider);
+  final box = Hive.box<Budget>(Boxes.budgets);
+  return BudgetRepo(box);
+});
+
+final currentMonthProvider = Provider<(int year, int month)>((ref) {
+  final now = DateTime.now().toUtc();
+  return (now.year, now.month);
+});
+
+final currentMonthBudgetProvider =
+    StreamProvider<Budget>((ref) {
+  final repo = ref.watch(budgetRepoProvider);
+  final (year, month) = ref.watch(currentMonthProvider);
+  return repo
+      .watchForMonth(year, month)
+      .map((b) => b ?? Budget.empty(year, month));
+});
+
+final categorySpendThisMonthProvider = Provider<Map<String, int>>((ref) {
+  final txs = ref.watch(transactionsProvider).value ?? [];
+  final (year, month) = ref.watch(currentMonthProvider);
+  final start = DateTime.utc(year, month);
+  final end = month == 12
+      ? DateTime.utc(year + 1, 1)
+      : DateTime.utc(year, month + 1);
+  final map = <String, int>{};
+  for (final tx in txs) {
+    if (tx.dateUtc.isBefore(end) && !tx.dateUtc.isBefore(start)) {
+      map[tx.category] = (map[tx.category] ?? 0) + tx.amountCents;
+    }
+  }
+  return map;
+});
+
+class CategoryBudgetInfo {
+  CategoryBudgetInfo({required this.limit, required this.spent});
+  final int limit;
+  final int spent;
+  int get remaining => limit - spent;
+}
+
+class BudgetOverview {
+  BudgetOverview({
+    required this.categories,
+    required this.totalLimit,
+    required this.totalSpent,
+  });
+
+  final Map<String, CategoryBudgetInfo> categories;
+  final int totalLimit;
+  final int totalSpent;
+  int get totalRemaining => totalLimit - totalSpent;
+  double get pctUsed =>
+      totalLimit == 0 ? 0 : totalSpent / totalLimit * 100;
+}
+
+final budgetOverviewProvider = Provider<BudgetOverview>((ref) {
+  final (year, month) = ref.watch(currentMonthProvider);
+  final budget = ref.watch(currentMonthBudgetProvider).maybeWhen(
+        data: (b) => b,
+        orElse: () => Budget.empty(year, month),
+      );
+  final spend = ref.watch(categorySpendThisMonthProvider);
+  final categories = {...budget.categoryLimits.keys, ...spend.keys};
+  final perCat = <String, CategoryBudgetInfo>{};
+  for (final c in categories) {
+    final limit = budget.categoryLimits[c] ?? 0;
+    final spent = spend[c] ?? 0;
+    perCat[c] = CategoryBudgetInfo(limit: limit, spent: spent);
+  }
+  final totalLimit =
+      perCat.values.fold<int>(0, (p, e) => p + e.limit);
+  final totalSpent =
+      perCat.values.fold<int>(0, (p, e) => p + e.spent);
+  return BudgetOverview(
+    categories: perCat,
+    totalLimit: totalLimit,
+    totalSpent: totalSpent,
+  );
+});
+
+/// Existing provider retained for backward compatibility.
 final monthSpendProvider = Provider<int>((ref) {
   ref.watch(transactionsProvider);
   final repo = ref.watch(transactionRepoProvider);

--- a/lib/data/models/budget.dart
+++ b/lib/data/models/budget.dart
@@ -1,23 +1,102 @@
 import 'package:hive/hive.dart';
 
-@HiveType(typeId: 1)
-class Budget extends HiveObject {
+/// Stores budget limits for a given month (current milestone only).
+class Budget {
   Budget({
     required this.id,
-    required this.periodMonth,
-    required this.periodYear,
+    required this.year,
+    required this.month,
     required this.categoryLimits,
-    this.rolloverEnabled = false,
+    required this.createdAtUtc,
+    required this.updatedAtUtc,
   });
 
-  @HiveField(0)
-  String id;
-  @HiveField(1)
-  int periodMonth;
-  @HiveField(2)
-  int periodYear;
-  @HiveField(3)
-  Map<String, int> categoryLimits;
-  @HiveField(4)
-  bool rolloverEnabled;
+  /// Composite id in the form `yyyy-mm` (UTC).
+  final String id;
+  final int year;
+  final int month;
+  final Map<String, int> categoryLimits;
+  final DateTime createdAtUtc;
+  final DateTime updatedAtUtc;
+
+  Budget copyWith({
+    Map<String, int>? categoryLimits,
+    DateTime? updatedAtUtc,
+  }) {
+    return Budget(
+      id: id,
+      year: year,
+      month: month,
+      categoryLimits: categoryLimits ?? this.categoryLimits,
+      createdAtUtc: createdAtUtc,
+      updatedAtUtc: updatedAtUtc ?? this.updatedAtUtc,
+    );
+  }
+
+  static String idFor(int year, int month) =>
+      '$year-${month.toString().padLeft(2, '0')}';
+
+  factory Budget.empty(int year, int month) {
+    final now = DateTime.now().toUtc();
+    return Budget(
+      id: idFor(year, month),
+      year: year,
+      month: month,
+      categoryLimits: {},
+      createdAtUtc: now,
+      updatedAtUtc: now,
+    );
+  }
+}
+
+class BudgetAdapter extends TypeAdapter<Budget> {
+  @override
+  final int typeId = 2;
+
+  @override
+  Budget read(BinaryReader reader) {
+    final id = reader.readString();
+    final year = reader.readInt();
+    final month = reader.readInt();
+    final len = reader.readInt();
+    final limits = <String, int>{};
+    for (var i = 0; i < len; i++) {
+      final key = reader.readString();
+      final value = reader.readInt();
+      limits[key] = value;
+    }
+    final createdAt = DateTime.fromMillisecondsSinceEpoch(
+      reader.readInt(),
+      isUtc: true,
+    );
+    final updatedAt = DateTime.fromMillisecondsSinceEpoch(
+      reader.readInt(),
+      isUtc: true,
+    );
+    return Budget(
+      id: id,
+      year: year,
+      month: month,
+      categoryLimits: limits,
+      createdAtUtc: createdAt,
+      updatedAtUtc: updatedAt,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Budget obj) {
+    writer
+      ..writeString(obj.id)
+      ..writeInt(obj.year)
+      ..writeInt(obj.month)
+      ..writeInt(obj.categoryLimits.length);
+    obj.categoryLimits.forEach((key, value) {
+      writer
+        ..writeString(key)
+        ..writeInt(value);
+    });
+    writer
+      ..writeInt(obj.createdAtUtc.millisecondsSinceEpoch)
+      ..writeInt(obj.updatedAtUtc.millisecondsSinceEpoch);
+  }
 }

--- a/lib/data/repos/budget_repo.dart
+++ b/lib/data/repos/budget_repo.dart
@@ -1,23 +1,40 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
 import '../models/budget.dart';
-import '../storage/hive_boxes.dart';
-
-final budgetRepoProvider = Provider((ref) => BudgetRepo());
 
 class BudgetRepo {
-  Box<Budget> get _box => Hive.box<Budget>(budgetsBox);
+  BudgetRepo(this._box);
+  final Box<Budget> _box;
 
-  Stream<List<Budget>> watchAll() {
-    return _box.watch().map((_) => _box.values.toList());
+  String _id(int year, int month) => Budget.idFor(year, month);
+
+  Budget? getForMonth(int year, int month) => _box.get(_id(year, month));
+
+  Stream<Budget?> watchForMonth(int year, int month) async* {
+    final id = _id(year, month);
+    yield _box.get(id);
+    yield* _box.watch(key: id).map((event) => event.value as Budget?);
   }
 
-  Future<void> save(Budget budget) async {
-    await _box.put(budget.id, budget);
+  Future<Budget> upsertForMonth(
+      int year, int month, Map<String, int> limits) async {
+    final id = _id(year, month);
+    final existing = _box.get(id);
+    final now = DateTime.now().toUtc();
+    final budget = Budget(
+      id: id,
+      year: year,
+      month: month,
+      categoryLimits: Map.from(limits),
+      createdAtUtc: existing?.createdAtUtc ?? now,
+      updatedAtUtc: now,
+    );
+    await _box.put(id, budget);
+    return budget;
   }
 
-  Future<void> remove(String id) async {
-    await _box.delete(id);
+  Future<void> updateLimits(
+      int year, int month, Map<String, int> limits) async {
+    await upsertForMonth(year, month, limits);
   }
 }

--- a/lib/data/storage/hive_boxes.dart
+++ b/lib/data/storage/hive_boxes.dart
@@ -1,10 +1,12 @@
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/transaction.dart';
+import '../models/budget.dart';
 
 class Boxes {
   Boxes._();
   static const transactions = 'bb_transactions';
+  static const budgets = 'bb_budgets';
 }
 
 Future<void> initHive() async {
@@ -12,5 +14,9 @@ Future<void> initHive() async {
   if (!Hive.isAdapterRegistered(BBTransactionAdapter().typeId)) {
     Hive.registerAdapter(BBTransactionAdapter());
   }
+  if (!Hive.isAdapterRegistered(BudgetAdapter().typeId)) {
+    Hive.registerAdapter(BudgetAdapter());
+  }
   await Hive.openBox<BBTransaction>(Boxes.transactions);
+  await Hive.openBox<Budget>(Boxes.budgets);
 }

--- a/lib/features/budgets/budgets_page.dart
+++ b/lib/features/budgets/budgets_page.dart
@@ -1,13 +1,142 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
-class BudgetsPage extends StatelessWidget {
+import '../../core/di/providers.dart';
+import '../../core/utils/currency.dart';
+
+class BudgetsPage extends ConsumerStatefulWidget {
   const BudgetsPage({super.key});
 
   @override
+  ConsumerState<BudgetsPage> createState() => _BudgetsPageState();
+}
+
+class _BudgetsPageState extends ConsumerState<BudgetsPage> {
+  final Map<String, TextEditingController> _controllers = {};
+  static const _defaultCats = [
+    'General',
+    'Food',
+    'Transport',
+    'Bills',
+    'Shopping',
+  ];
+
+  void _syncControllers(Map<String, int> limits) {
+    final categories = {..._defaultCats, ...limits.keys};
+    for (final c in categories) {
+      final txt = limits[c] != null && limits[c]! > 0
+          ? (limits[c]! / 100).toString()
+          : '';
+      if (_controllers.containsKey(c)) {
+        if (_controllers[c]!.text != txt) {
+          _controllers[c]!.text = txt;
+        }
+      } else {
+        _controllers[c] = TextEditingController(text: txt);
+      }
+    }
+  }
+
+  void _apply(int year, int month, List<String> categories) {
+    final limits = <String, int>{};
+    for (final c in categories) {
+      final parsed = parseCurrency(_controllers[c]!.text) ?? 0;
+      limits[c] = parsed < 0 ? 0 : parsed;
+    }
+    ref.read(budgetRepoProvider).updateLimits(year, month, limits);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: AppBar(title: Text('Budgets')),
-      body: Center(child: Text('No budgets yet')),
+    final (year, month) = ref.watch(currentMonthProvider);
+    final budgetAsync = ref.watch(currentMonthBudgetProvider);
+    final spend = ref.watch(categorySpendThisMonthProvider);
+    return budgetAsync.when(
+      data: (budget) {
+        _syncControllers(budget.categoryLimits);
+        final categories = {
+          ..._defaultCats,
+          ...budget.categoryLimits.keys,
+          ...spend.keys
+        }.toList()
+          ..sort();
+        final monthLabel = DateFormat('MMMM yyyy')
+            .format(DateTime.utc(year, month));
+        return Scaffold(
+          appBar: AppBar(title: const Text('Budgets')),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(monthLabel, style: Theme.of(context).textTheme.titleLarge),
+              const SizedBox(height: 16),
+              for (final c in categories)
+                _CategoryRow(
+                  category: c,
+                  controller: _controllers[c]!,
+                  spent: spend[c] ?? 0,
+                  limit: budget.categoryLimits[c] ?? 0,
+                ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () => _apply(year, month, categories),
+                child: const Text('Apply'),
+              ),
+            ],
+          ),
+        );
+      },
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, st) => Scaffold(body: Center(child: Text('Error: $e'))),
+    );
+  }
+}
+
+class _CategoryRow extends StatelessWidget {
+  const _CategoryRow({
+    required this.category,
+    required this.controller,
+    required this.spent,
+    required this.limit,
+  });
+
+  final String category;
+  final TextEditingController controller;
+  final int spent;
+  final int limit;
+
+  @override
+  Widget build(BuildContext context) {
+    final remaining = limit - spent;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(category),
+                const SizedBox(height: 4),
+                Text(
+                  'Spent ${formatCents(spent)} • Remaining ${formatCents(remaining)}',
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: 100,
+            child: TextField(
+              key: Key('limit_$category'),
+              controller: controller,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(hintText: '0'),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/dashboard/dashboard_page.dart
+++ b/lib/features/dashboard/dashboard_page.dart
@@ -9,7 +9,12 @@ class DashboardPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final total = ref.watch(monthSpendProvider);
+    final overview = ref.watch(budgetOverviewProvider);
+    final totalLimit = overview.totalLimit;
+    final totalSpent = overview.totalSpent;
+    final pct = overview.pctUsed;
+    final progress =
+        totalLimit == 0 ? 0.0 : (totalSpent / totalLimit).clamp(0, 1);
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
       body: ListView(
@@ -21,12 +26,16 @@ class DashboardPage extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text('This Month Spend'),
+                  const Text('Budget This Month'),
                   const SizedBox(height: 8),
-                  Text(
-                    formatCents(total),
-                    style: Theme.of(context).textTheme.headlineMedium,
-                  ),
+                  if (totalLimit == 0)
+                    const Text('No budget set')
+                  else ...[
+                    Text(
+                      '${formatCents(totalSpent)} / ${formatCents(totalLimit)} • ${pct.toStringAsFixed(0)}%'),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(value: progress),
+                  ],
                 ],
               ),
             ),

--- a/test/unit/budget_derivations_test.dart
+++ b/test/unit/budget_derivations_test.dart
@@ -1,0 +1,80 @@
+import 'package:budget_balanced/core/di/providers.dart';
+import 'package:budget_balanced/data/models/budget.dart';
+import 'package:budget_balanced/data/models/transaction.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  test('aggregation and totals', () async {
+    final txs = [
+      BBTransaction(
+        id: '1',
+        amountCents: 500,
+        dateUtc: DateTime.utc(2023, 1, 10),
+        merchant: 'A',
+        category: 'Food',
+        paymentType: 'Card',
+        note: '',
+      ),
+      BBTransaction(
+        id: '2',
+        amountCents: 100,
+        dateUtc: DateTime.utc(2023, 1, 12),
+        merchant: 'B',
+        category: 'Transport',
+        paymentType: 'Card',
+        note: '',
+      ),
+      BBTransaction(
+        id: '3',
+        amountCents: 200,
+        dateUtc: DateTime.utc(2023, 2, 1), // next month
+        merchant: 'C',
+        category: 'Food',
+        paymentType: 'Card',
+        note: '',
+      ),
+    ];
+    final now = DateTime.utc(2023, 1, 1);
+    final budget = Budget(
+      id: Budget.idFor(2023, 1),
+      year: 2023,
+      month: 1,
+      categoryLimits: {'Food': 400, 'Transport': 300},
+      createdAtUtc: now,
+      updatedAtUtc: now,
+    );
+    final container = ProviderContainer(overrides: [
+      currentMonthProvider.overrideWithValue((2023, 1)),
+      transactionsProvider.overrideWith((ref) => Stream.value(txs)),
+      currentMonthBudgetProvider.overrideWith((ref) => Stream.value(budget)),
+    ]);
+
+    final spend = container.read(categorySpendThisMonthProvider);
+    expect(spend['Food'], 500);
+    expect(spend['Transport'], 100);
+    expect(spend.containsKey('Other'), false);
+
+    final overview = container.read(budgetOverviewProvider);
+    final food = overview.categories['Food']!;
+    expect(food.limit, 400);
+    expect(food.spent, 500);
+    expect(food.remaining, -100);
+    expect(overview.totalLimit, 700);
+    expect(overview.totalSpent, 600);
+    expect(overview.totalRemaining, 100);
+    expect(overview.pctUsed, closeTo(600 / 700 * 100, 0.001));
+  });
+
+  test('zero budget totals', () {
+    final container = ProviderContainer(overrides: [
+      currentMonthProvider.overrideWithValue((2023, 1)),
+      transactionsProvider.overrideWith((ref) => const Stream.empty()),
+      currentMonthBudgetProvider.overrideWith(
+          (ref) => Stream.value(Budget.empty(2023, 1))),
+    ]);
+    final overview = container.read(budgetOverviewProvider);
+    expect(overview.totalLimit, 0);
+    expect(overview.pctUsed, 0);
+  });
+}

--- a/test/unit/budget_repo_test.dart
+++ b/test/unit/budget_repo_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:budget_balanced/data/models/budget.dart';
+import 'package:budget_balanced/data/repos/budget_repo.dart';
+import 'package:budget_balanced/data/storage/hive_boxes.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+void main() {
+  late Box<Budget> box;
+  late BudgetRepo repo;
+
+  setUp(() async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(BudgetAdapter());
+    box = await Hive.openBox<Budget>(Boxes.budgets);
+    repo = BudgetRepo(box);
+  });
+
+  tearDown(() async {
+    await box.deleteFromDisk();
+  });
+
+  test('create/update/watch', () async {
+    final b1 = await repo.upsertForMonth(2023, 1, {'Food': 100});
+    expect(b1.categoryLimits['Food'], 100);
+    final fetched = repo.getForMonth(2023, 1);
+    expect(fetched!.createdAtUtc, b1.createdAtUtc);
+    await Future.delayed(const Duration(milliseconds: 10));
+    await repo.updateLimits(2023, 1, {'Food': 200});
+    final b2 = repo.getForMonth(2023, 1)!;
+    expect(b2.categoryLimits['Food'], 200);
+    expect(b2.createdAtUtc, b1.createdAtUtc);
+    expect(b2.updatedAtUtc.isAfter(b1.updatedAtUtc), true);
+    final watched = await repo.watchForMonth(2023, 1).last;
+    expect(watched!.categoryLimits['Food'], 200);
+  });
+}

--- a/test/widget/budgets_page_test.dart
+++ b/test/widget/budgets_page_test.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:budget_balanced/app.dart';
+import 'package:budget_balanced/core/di/providers.dart';
+import 'package:budget_balanced/core/utils/currency.dart';
+import 'package:budget_balanced/data/models/budget.dart';
+import 'package:budget_balanced/data/models/transaction.dart';
+import 'package:budget_balanced/data/repos/transaction_repo.dart';
+import 'package:budget_balanced/data/storage/hive_boxes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+void main() {
+  late List<Override> overrides;
+
+  setUp(() async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(BBTransactionAdapter());
+    Hive.registerAdapter(BudgetAdapter());
+    await Hive.openBox<BBTransaction>(Boxes.transactions);
+    await Hive.openBox<Budget>(Boxes.budgets);
+    overrides = [
+      hiveReadyProvider.overrideWith((ref) async {}),
+    ];
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk(Boxes.transactions);
+    await Hive.deleteBoxFromDisk(Boxes.budgets);
+  });
+
+  testWidgets('edit limits and reflect in UI', (tester) async {
+    await tester.pumpWidget(ProviderScope(overrides: overrides, child: const App()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Budgets'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('limit_Food')), '100');
+    await tester.tap(find.text('Apply'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Spent ${formatCents(0)} • Remaining ${formatCents(10000)}'),
+      findsOneWidget,
+    );
+
+    final repo = TransactionRepo(Hive.box<BBTransaction>(Boxes.transactions));
+    await repo.add(BBTransaction(
+      id: '1',
+      amountCents: 5000,
+      dateUtc: DateTime.now().toUtc(),
+      merchant: 'Shop',
+      category: 'Food',
+      paymentType: 'Card',
+      note: '',
+    ));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Spent ${formatCents(5000)} • Remaining ${formatCents(5000)}'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Dashboard'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(
+          '${formatCents(5000)} / ${formatCents(10000)} • 50%'),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Introduce `Budget` Hive model and repository for monthly limits
- Compute spend vs budget via new Riverpod providers
- Add editable Budgets page and dashboard Spend-vs-Budget card
- Include unit and widget tests for budget logic and UI

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689a3bcf9484833196b4553eb44cefdb