### PR TITLE
Add professional dashboard savings header

### DIFF
--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -1,23 +1,128 @@
+import 'dart:math';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
+import '../../data/models/budget.dart';
 import '../../data/models/transaction.dart';
+import '../../data/repos/budget_repo.dart';
 import '../../data/repos/transaction_repo.dart';
 import '../../data/storage/hive_boxes.dart';
 
+/// Provides the current UTC month `(year, month)`.
+final currentMonthProvider = Provider<(int, int)>((ref) {
+  final now = DateTime.now().toUtc();
+  return (now.year, now.month);
+});
+
+/// Repositories
 final transactionRepoProvider = Provider<TransactionRepo>((ref) {
   final box = Hive.box<BBTransaction>(Boxes.transactions);
   return TransactionRepo(box);
 });
 
+final budgetRepoProvider = Provider<BudgetRepo>((ref) {
+  final box = Hive.box<Budget>(Boxes.budgets);
+  return BudgetRepo(box);
+});
+
+/// Streams
 final transactionsProvider =
     StreamProvider<List<BBTransaction>>((ref) {
   final repo = ref.watch(transactionRepoProvider);
   return repo.watchAll();
 });
 
-final monthSpendProvider = Provider<int>((ref) {
+final currentMonthBudgetProvider =
+    StreamProvider<Budget>((ref) {
+  final repo = ref.watch(budgetRepoProvider);
+  final (year, month) = ref.watch(currentMonthProvider);
+  return repo
+      .watchForMonth(year, month)
+      .map((b) => b ?? Budget.empty(year, month));
+});
+
+/// Spend totals
+final totalSpentThisMonthProvider = Provider<int>((ref) {
   ref.watch(transactionsProvider);
   final repo = ref.watch(transactionRepoProvider);
   return repo.totalSpentThisMonthCents(DateTime.now().toUtc());
 });
+
+/// Category spend map
+final categorySpendThisMonthProvider = Provider<Map<String, int>>((ref) {
+  final txs =
+      ref.watch(transactionsProvider).maybeWhen(data: (v) => v, orElse: () => const []);
+  final (year, month) = ref.watch(currentMonthProvider);
+  final map = <String, int>{};
+  for (final tx in txs) {
+    if (tx.dateUtc.year == year && tx.dateUtc.month == month) {
+      map[tx.category] = (map[tx.category] ?? 0) + tx.amountCents;
+    }
+  }
+  return map;
+});
+
+/// Models for budget overview
+class BudgetCategoryOverview {
+  BudgetCategoryOverview({required this.limit, required this.spent});
+  final int limit;
+  final int spent;
+  int get remaining => limit - spent;
+}
+
+class BudgetOverview {
+  BudgetOverview({
+    required this.categories,
+    required this.totalLimit,
+    required this.totalSpent,
+  });
+  final Map<String, BudgetCategoryOverview> categories;
+  final int totalLimit;
+  final int totalSpent;
+  int get totalRemaining => totalLimit - totalSpent;
+  double get pctUsed => totalLimit == 0 ? 0 : totalSpent / totalLimit * 100;
+}
+
+/// Aggregate current month budget and spend information.
+final budgetOverviewProvider = Provider<BudgetOverview>((ref) {
+  final budget = ref.watch(currentMonthBudgetProvider).asData?.value;
+  final spend = ref.watch(categorySpendThisMonthProvider);
+  final categories = <String, BudgetCategoryOverview>{};
+  final limits = budget?.categoryLimits ?? const {};
+  final allCats = {...limits.keys, ...spend.keys};
+  for (final c in allCats) {
+    final limit = limits[c] ?? 0;
+    final spent = spend[c] ?? 0;
+    categories[c] = BudgetCategoryOverview(limit: limit, spent: spent);
+  }
+  final totalLimit = limits.values.fold(0, (s, v) => s + v);
+  final totalSpent = spend.values.fold(0, (s, v) => s + v);
+  return BudgetOverview(
+    categories: categories,
+    totalLimit: totalLimit,
+    totalSpent: totalSpent,
+  );
+});
+
+/// Totals for dashboard header
+final totalBudgetThisMonthProvider = Provider<int>((ref) {
+  final overview = ref.watch(budgetOverviewProvider);
+  return overview.totalLimit;
+});
+
+final savedThisMonthProvider = Provider<int>((ref) {
+  final totalBudget = ref.watch(totalBudgetThisMonthProvider);
+  final totalSpent = ref.watch(totalSpentThisMonthProvider);
+  return max(totalBudget - totalSpent, 0);
+});
+
+final remainingThisMonthProvider = Provider<int>((ref) {
+  final totalBudget = ref.watch(totalBudgetThisMonthProvider);
+  final totalSpent = ref.watch(totalSpentThisMonthProvider);
+  return totalBudget - totalSpent;
+});
+
+// Backwards compatibility
+@Deprecated('Use totalSpentThisMonthProvider')
+final monthSpendProvider = totalSpentThisMonthProvider;

--- a/lib/data/storage/hive_boxes.dart
+++ b/lib/data/storage/hive_boxes.dart
@@ -1,10 +1,12 @@
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/transaction.dart';
+import '../models/budget.dart';
 
 class Boxes {
   Boxes._();
   static const transactions = 'bb_transactions';
+  static const budgets = 'bb_budgets';
 }
 
 Future<void> initHive() async {
@@ -12,5 +14,9 @@ Future<void> initHive() async {
   if (!Hive.isAdapterRegistered(BBTransactionAdapter().typeId)) {
     Hive.registerAdapter(BBTransactionAdapter());
   }
+  if (!Hive.isAdapterRegistered(BudgetAdapter().typeId)) {
+    Hive.registerAdapter(BudgetAdapter());
+  }
   await Hive.openBox<BBTransaction>(Boxes.transactions);
+  await Hive.openBox<Budget>(Boxes.budgets);
 }

--- a/lib/features/dashboard/dashboard_page.dart
+++ b/lib/features/dashboard/dashboard_page.dart
@@ -3,18 +3,27 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/di/providers.dart';
 import '../../core/utils/currency.dart';
+import '../../widgets/dashboard_header.dart';
 
 class DashboardPage extends ConsumerWidget {
   const DashboardPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final spent = ref.watch(monthSpendProvider);
+    final saved = ref.watch(savedThisMonthProvider);
+    final remaining = ref.watch(remainingThisMonthProvider);
+    final totalBudget = ref.watch(totalBudgetThisMonthProvider);
+    final spent = ref.watch(totalSpentThisMonthProvider);
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          DashboardHeader(
+            savedCents: totalBudget == 0 ? 0 : saved,
+            remainingCents: totalBudget == 0 ? 0 : remaining,
+          ),
+          const SizedBox(height: 16),
           Card(
             child: Padding(
               padding: const EdgeInsets.all(16),

--- a/lib/widgets/dashboard_header.dart
+++ b/lib/widgets/dashboard_header.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../core/utils/currency.dart';
+
+class DashboardHeader extends StatelessWidget {
+  const DashboardHeader({
+    super.key,
+    required this.savedCents,
+    required this.remainingCents,
+  });
+
+  final int savedCents;
+  final int remainingCents;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final savedStyle = theme.textTheme.headlineMedium?.copyWith(
+      color: savedCents > 0 ? theme.colorScheme.primary : null,
+    );
+    final hasBudget = !(savedCents == 0 && remainingCents == 0);
+    final remainingColor = hasBudget && remainingCents < 0
+        ? theme.colorScheme.error
+        : theme.textTheme.bodyMedium?.color;
+    final remainingLabel = hasBudget
+        ? '${formatCents(remainingCents)} left in budget'
+        : 'No budget set.';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          "You've Saved ${formatCents(savedCents)}",
+          style: savedStyle,
+        ),
+        Text(
+          remainingLabel,
+          style: theme.textTheme.bodyMedium?.copyWith(color: remainingColor),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- compute monthly budget and spending providers
- track budgets in Hive storage
- add reusable DashboardHeader widget and integrate into dashboard

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ac85fe190833186b115d68dbd1cac